### PR TITLE
Corrected groupeId of gnu-crypto in pom.xml was gnu-plot is now org.gnu

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
       <version>2.5.0</version>
     </dependency>
     <dependency>
-      <groupId>gnu-crypto</groupId>
+      <groupId>org.gnu</groupId>
       <artifactId>gnu-crypto</artifactId>
       <version>2.0.1</version>
     </dependency>


### PR DESCRIPTION
The groupeId of gnu-crypto was incorrect for public developpement.
The value was gnu-crypto, maybe a dependency deployed locally ?

The new value of groupeId is now org.gnu which allow users to use the project.
